### PR TITLE
feat: Initial database schema and data access layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+
+/generated/prisma

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,359 @@
+{
+  "name": "wins-mvp-db",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wins-mvp-db",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@prisma/client": "^6.11.1"
+      },
+      "devDependencies": {
+        "prisma": "^6.11.1",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
+      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.11.1.tgz",
+      "integrity": "sha512-5CLFh8QP6KxRm83pJ84jaVCeSVPQr8k0L2SEtOJHwdkS57/VQDcI/wQpGmdyOZi+D9gdNabdo8tj1Uk+w+upsQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/config": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.11.1.tgz",
+      "integrity": "sha512-z6rCTQN741wxDq82cpdzx2uVykpnQIXalLhrWQSR0jlBVOxCIkz3HZnd8ern3uYTcWKfB3IpVAF7K2FU8t/8AQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jiti": "2.4.2"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.11.1.tgz",
+      "integrity": "sha512-lWRb/YSWu8l4Yum1UXfGLtqFzZkVS2ygkWYpgkbgMHn9XJlMITIgeMvJyX5GepChzhmxuSuiq/MY/kGFweOpGw==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.11.1.tgz",
+      "integrity": "sha512-6eKEcV6V8W2eZAUwX2xTktxqPM4vnx3sxz3SDtpZwjHKpC6lhOtc4vtAtFUuf5+eEqBk+dbJ9Dcaj6uQU+FNNg==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.11.1",
+        "@prisma/engines-version": "6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9",
+        "@prisma/fetch-engine": "6.11.1",
+        "@prisma/get-platform": "6.11.1"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9.tgz",
+      "integrity": "sha512-swFJTOOg4tHyOM1zB/pHb3MeH0i6t7jFKn5l+ZsB23d9AQACuIRo9MouvuKGvnDogzkcjbWnXi/NvOZ0+n5Jfw==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.11.1.tgz",
+      "integrity": "sha512-NBYzmkXTkj9+LxNPRSndaAeALOL1Gr3tjvgRYNqruIPlZ6/ixLeuE/5boYOewant58tnaYFZ5Ne0jFBPfGXHpQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.11.1",
+        "@prisma/engines-version": "6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9",
+        "@prisma/get-platform": "6.11.1"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.11.1.tgz",
+      "integrity": "sha512-b2Z8oV2gwvdCkFemBTFd0x4lsL4O2jLSx8lB7D+XqoFALOQZPa7eAPE1NU0Mj1V8gPHRxIsHnyUNtw2i92psUw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.11.1"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
+      "integrity": "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "devOptional": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/prisma": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.11.1.tgz",
+      "integrity": "sha512-VzJToRlV0s9Vu2bfqHiRJw73hZNCG/AyJeX+kopbu4GATTjTUdEWUteO3p4BLYoHpMS4o8pD3v6tF44BHNZI1w==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "6.11.1",
+        "@prisma/engines": "6.11.1"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "wins-mvp-db",
+  "version": "1.0.0",
+  "description": "Database and data management for WINS MVP",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prisma:seed": "ts-node prisma/seed.ts"
+  },
+  "prisma": {
+    "seed": "ts-node prisma/seed.ts"
+  },
+  "keywords": [
+    "prisma",
+    "postgresql",
+    "sales",
+    "ai"
+  ],
+  "author": "AI Augmented Selling - WINS™ MVP Team",
+  "license": "ISC",
+  "devDependencies": {
+    "prisma": "^6.11.1",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "@prisma/client": "^6.11.1"
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,74 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        String   @id @default(uuid())
+  email     String   @unique
+  name      String
+  company   String?
+  role      String?
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+  deals     Deal[]
+  guides    Guide[]
+}
+
+model Deal {
+  id          String   @id @default(uuid())
+  userId      String   @map("user_id")
+  contactName String   @map("contact_name")
+  company     String
+  stage       DealStage
+  context     String?
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+  deletedAt   DateTime? @map("deleted_at") // For soft deletes
+  user        User     @relation(fields: [userId], references: [id])
+  guides      Guide[]
+
+  @@index([userId])
+  @@index([stage])
+}
+
+model Guide {
+  id           String      @id @default(uuid())
+  userId       String      @map("user_id")
+  dealId       String      @map("deal_id")
+  content      Json? // Or String, depending on final decision
+  meetingType  MeetingType @map("meeting_type")
+  generatedAt  DateTime    @default(now()) @map("generated_at")
+  deletedAt    DateTime?   @map("deleted_at") // For soft deletes
+  // No updatedAt needed for guides as they are typically immutable once generated
+  // If guides can be edited, add: updatedAt DateTime @updatedAt @map("updated_at")
+
+  user User @relation(fields: [userId], references: [id])
+  deal Deal @relation(fields: [dealId], references: [id])
+
+  @@index([userId])
+  @@index([dealId])
+  @@index([meetingType])
+}
+
+enum DealStage {
+  PROSPECTING
+  DISCOVERY
+  PROPOSAL
+  NEGOTIATION
+  CLOSING
+}
+
+enum MeetingType {
+  DISCOVERY
+  DEMO
+  PROPOSAL
+  NEGOTIATION
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,92 @@
+import { PrismaClient, DealStage, MeetingType } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log(`Start seeding ...`);
+
+  // Create Users
+  const user1 = await prisma.user.create({
+    data: {
+      email: 'alice@example.com',
+      name: 'Alice Wonderland',
+      company: 'Wonderland Inc.',
+      role: 'Sales Rep',
+    },
+  });
+
+  const user2 = await prisma.user.create({
+    data: {
+      email: 'bob@example.com',
+      name: 'Bob The Builder',
+      company: 'Construction Co.',
+      role: 'Account Manager',
+    },
+  });
+
+  console.log(`Created users: ${user1.name}, ${user2.name}`);
+
+  // Create Deals for User1
+  const deal1User1 = await prisma.deal.create({
+    data: {
+      userId: user1.id,
+      contactName: 'Mad Hatter',
+      company: 'TeaParty LLC',
+      stage: DealStage.PROSPECTING,
+      context: 'Initial contact made, interested in our AI solution.',
+    },
+  });
+
+  const deal2User1 = await prisma.deal.create({
+    data: {
+      userId: user1.id,
+      contactName: 'Cheshire Cat',
+      company: 'Grinning Goods',
+      stage: DealStage.DISCOVERY,
+      context: 'Scheduled a discovery call to understand needs.',
+    },
+  });
+
+  console.log(`Created deals for ${user1.name}`);
+
+  // Create Deals for User2
+  const deal1User2 = await prisma.deal.create({
+    data: {
+      userId: user2.id,
+      contactName: 'Wendy',
+      company: 'FixIt Felix Jr.',
+      stage: DealStage.PROPOSAL,
+      context: 'Sent proposal for construction management software.',
+    },
+  });
+
+  console.log(`Created deals for ${user2.name}`);
+
+  // Create Guides for Deal1User1
+  const guide1Deal1User1 = await prisma.guide.create({
+    data: {
+      userId: user1.id,
+      dealId: deal1User1.id,
+      meetingType: MeetingType.DISCOVERY,
+      content: {
+        greeting: "Hello Mad Hatter!",
+        keyQuestions: ["What are your biggest challenges with tea parties?", "How can AI improve your guest experience?"],
+        talkingPoints: ["Our AI can predict tea preferences.", "Automated RSVP management."]
+      }
+    },
+  });
+
+  console.log(`Created guides for ${deal1User1.contactName}`);
+
+  console.log(`Seeding finished.`);
+}
+
+main()
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/services/dealService.ts
+++ b/src/services/dealService.ts
@@ -1,0 +1,130 @@
+import { PrismaClient, Deal, DealStage } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+// Define types for input data
+type DealCreateData = {
+  userId: string;
+  contactName: string;
+  company: string;
+  stage: DealStage;
+  context?: string | null;
+};
+
+type DealUpdateData = Partial<Omit<DealCreateData, 'userId'>>; // userId typically shouldn't be updated
+
+export const dealService = {
+  async createDeal(data: DealCreateData): Promise<Deal> {
+    if (!data.userId || !data.contactName || !data.company || !data.stage) {
+      throw new Error('User ID, contact name, company, and stage are required for creating a deal.');
+    }
+    // Ensure user exists
+    const userExists = await prisma.user.findUnique({ where: { id: data.userId } });
+    if (!userExists) {
+      throw new Error(`User with ID ${data.userId} not found.`);
+    }
+    return prisma.deal.create({ data });
+  },
+
+  async getAllDeals(): Promise<Deal[]> {
+    return prisma.deal.findMany({
+      where: { deletedAt: null },
+      include: { user: true, guides: true }, // Optionally include related user and guides
+    });
+  },
+
+  async getDealById(id: string): Promise<Deal | null> {
+    return prisma.deal.findUnique({
+      where: { id, deletedAt: null },
+      include: { user: true, guides: true }, // Optionally include related user and guides
+    });
+  },
+
+  async getDealsByUserId(userId: string): Promise<Deal[]> {
+    return prisma.deal.findMany({
+      where: { userId, deletedAt: null },
+      include: { guides: true }, // Optionally include related guides
+    });
+  },
+
+  async getDealsByStage(userId: string, stage: DealStage): Promise<Deal[]> {
+    // First, ensure the user exists (optional, but good practice if userId isn't validated upstream)
+    // const user = await prisma.user.findUnique({ where: { id: userId } });
+    // if (!user) {
+    //   throw new Error(`User with ID ${userId} not found.`);
+    // }
+    return prisma.deal.findMany({
+      where: { userId, stage, deletedAt: null },
+      include: {
+        // user: true, // Not needed as we are querying for a specific user
+        guides: true
+      },
+    });
+  },
+
+  // Method to get deals including soft-deleted ones, for admin purposes perhaps
+  async getAllDealsIncludingDeleted(): Promise<Deal[]> {
+    return prisma.deal.findMany({
+      include: { user: true, guides: true },
+    });
+  },
+
+  async updateDeal(id: string, data: DealUpdateData): Promise<Deal | null> {
+    if (data.contactName === '') {
+      throw new Error('Contact name cannot be empty.');
+    }
+    if (data.company === '') {
+      throw new Error('Company cannot be empty.');
+    }
+    // Add other specific field validations as necessary e.g. for stage
+    if (data.stage && !Object.values(DealStage).includes(data.stage)) {
+        throw new Error(`Invalid deal stage: ${data.stage}`);
+    }
+
+    // Ensure the deal exists before attempting to update
+    const dealExists = await prisma.deal.findUnique({ where: { id } });
+    if (!dealExists) {
+        throw new Error(`Deal with ID ${id} not found.`);
+    }
+
+    return prisma.deal.update({
+      where: { id },
+      data,
+    });
+  },
+
+  // Soft delete a deal
+  async deleteDeal(id: string): Promise<Deal | null> {
+    // Before soft deleting, ensure the deal exists and is not already deleted
+    const deal = await prisma.deal.findUnique({
+        where: { id, deletedAt: null },
+    });
+
+    if (!deal) {
+        throw new Error(`Deal with ID ${id} not found or already deleted.`);
+    }
+
+    // Note: Soft deleting a deal does not automatically soft-delete its guides.
+    // This logic would need to be added if required (e.g., iterate guides and soft delete them).
+    // For now, guides will remain, but queries for guides should also check if their parent deal is soft-deleted if necessary.
+    return prisma.deal.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+  },
+
+  // Hard delete a deal (permanent)
+  async forceDeleteDeal(id: string): Promise<Deal | null> {
+    // This is a permanent deletion.
+    // Consider implications for related guides if not handled by schema (onDelete: Cascade)
+    // If guides should also be hard-deleted, a transaction might be needed:
+    // return prisma.$transaction(async (tx) => {
+    //   await tx.guide.deleteMany({ where: { dealId: id } }); // or soft delete guides first
+    //   return tx.deal.delete({ where: { id } });
+    // });
+    // For now, assuming if hard-delete is called, related data is handled or accepted to be restricted by FK constraints
+    return prisma.deal.delete({
+      where: { id }, // This will delete regardless of deletedAt status
+    });
+  },
+};

--- a/src/services/guideService.ts
+++ b/src/services/guideService.ts
@@ -1,0 +1,114 @@
+import { PrismaClient, Guide, MeetingType, Prisma } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+// Define types for input data
+// Prisma.JsonValue is used for the 'content' field if it's defined as Json in schema
+type GuideCreateData = {
+  userId: string;
+  dealId: string;
+  meetingType: MeetingType;
+  content?: Prisma.JsonValue | null; // Or string if content is Text
+};
+
+// Guides are often immutable once created. If updates are allowed:
+type GuideUpdateData = Partial<{
+  meetingType: MeetingType;
+  content: Prisma.JsonValue | null; // Or string
+}>;
+
+export const guideService = {
+  async createGuide(data: GuideCreateData): Promise<Guide> {
+    if (!data.userId || !data.dealId || !data.meetingType) {
+      throw new Error('User ID, Deal ID, and Meeting Type are required for creating a guide.');
+    }
+    // Ensure user exists
+    const userExists = await prisma.user.findUnique({ where: { id: data.userId } });
+    if (!userExists) {
+      throw new Error(`User with ID ${data.userId} not found.`);
+    }
+    // Ensure deal exists
+    const dealExists = await prisma.deal.findUnique({ where: { id: data.dealId } });
+    if (!dealExists) {
+      throw new Error(`Deal with ID ${data.dealId} not found.`);
+    }
+    // Ensure the deal belongs to the user (optional, but good for data integrity)
+    if (dealExists.userId !== data.userId) {
+        throw new Error(`Deal with ID ${data.dealId} does not belong to user ${data.userId}.`);
+    }
+
+    return prisma.guide.create({ data });
+  },
+
+  async getAllGuides(): Promise<Guide[]> {
+    return prisma.guide.findMany({
+      where: { deletedAt: null },
+      include: { user: true, deal: true }, // Optionally include related user and deal
+    });
+  },
+
+  async getGuideById(id: string): Promise<Guide | null> {
+    return prisma.guide.findUnique({
+      where: { id, deletedAt: null },
+      include: { user: true, deal: true }, // Optionally include related user and deal
+    });
+  },
+
+  async getGuidesByUserId(userId: string): Promise<Guide[]> {
+    return prisma.guide.findMany({
+      where: { userId, deletedAt: null },
+      include: { deal: true }, // Optionally include related deal
+    });
+  },
+
+  async getGuidesByDealId(dealId: string): Promise<Guide[]> {
+    // Also check if the parent deal is not soft-deleted
+    const deal = await prisma.deal.findUnique({ where: { id: dealId, deletedAt: null }});
+    if (!deal) {
+        // Or return empty array, depending on desired behavior if deal is deleted or not found
+        throw new Error(`Deal with ID ${dealId} not found or has been deleted.`);
+    }
+    return prisma.guide.findMany({
+      where: { dealId, deletedAt: null },
+      include: { user: true }, // Optionally include related user
+    });
+  },
+
+  // Method to get guides including soft-deleted ones, for admin purposes perhaps
+  async getAllGuidesIncludingDeleted(): Promise<Guide[]> {
+    return prisma.guide.findMany({
+      include: { user: true, deal: true },
+    });
+  },
+
+  // If guides are updatable, uncomment this:
+  // async updateGuide(id: string, data: GuideUpdateData): Promise<Guide | null> {
+  //   return prisma.guide.update({
+  //     where: { id },
+  //     data,
+  //   });
+  // },
+
+  // Soft delete a guide
+  async deleteGuide(id: string): Promise<Guide | null> {
+    const guide = await prisma.guide.findUnique({
+        where: { id, deletedAt: null }
+    });
+
+    if (!guide) {
+        throw new Error(`Guide with ID ${id} not found or already deleted.`);
+    }
+
+    return prisma.guide.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+  },
+
+  // Hard delete a guide (permanent)
+  async forceDeleteGuide(id: string): Promise<Guide | null> {
+    return prisma.guide.delete({
+      where: { id }, // This will delete regardless of deletedAt status
+    });
+  },
+};

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,0 +1,98 @@
+import { PrismaClient, User } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+// Basic email validation regex (simplified)
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// Define types for input data to ensure type safety
+// Note: Prisma generates types that can often be used directly or adapted.
+// For instance, Prisma.UserCreateInput could be used.
+// However, custom types allow for more specific validation points if needed.
+export type UserCreateData = {
+  email: string;
+  name: string;
+  company?: string | null;
+  role?: string | null;
+};
+
+export type UserUpdateData = Partial<UserCreateData>;
+
+export const userService = {
+  async createUser(data: UserCreateData): Promise<User> {
+    if (!data.email || !data.name) {
+      throw new Error('Email and name are required for creating a user.');
+    }
+    if (!EMAIL_REGEX.test(data.email)) {
+      throw new Error('Invalid email format.');
+    }
+    // Check if email already exists
+    const existingUser = await prisma.user.findUnique({ where: { email: data.email } });
+    if (existingUser) {
+      throw new Error('User with this email already exists.');
+    }
+    return prisma.user.create({ data });
+  },
+
+  async getAllUsers(): Promise<User[]> {
+    return prisma.user.findMany({
+      include: { deals: true, guides: true }, // Optionally include related data
+    });
+  },
+
+  async getUserById(id: string): Promise<User | null> {
+    return prisma.user.findUnique({
+      where: { id },
+      include: { deals: true, guides: true }, // Optionally include related data
+    });
+  },
+
+  async getUserByEmail(email: string): Promise<User | null> {
+    return prisma.user.findUnique({
+      where: { email },
+      include: { deals: true, guides: true }, // Optionally include related data
+    });
+  },
+
+  async updateUser(id: string, data: UserUpdateData): Promise<User | null> {
+    if (data.email === '') {
+      throw new Error('Email cannot be empty.');
+    }
+    if (data.email && !EMAIL_REGEX.test(data.email)) {
+      throw new Error('Invalid email format.');
+    }
+    if (data.name === '') {
+      throw new Error('Name cannot be empty.');
+    }
+    // If email is being changed, check if the new email already exists for another user
+    if (data.email) {
+      const existingUser = await prisma.user.findUnique({ where: { email: data.email } });
+      if (existingUser && existingUser.id !== id) {
+        throw new Error('Another user with this email already exists.');
+      }
+    }
+    return prisma.user.update({
+      where: { id },
+      data,
+    });
+  },
+
+  async deleteUser(id: string): Promise<User | null> {
+    // Consider implications of deleting a user with related deals/guides.
+    // Prisma by default might prevent deletion if there are related records
+    // depending on relation settings (e.g. onDelete: Cascade | Restrict).
+    // The current schema does not specify onDelete behavior, so it defaults to Restrict.
+    // This means deletion will fail if user has related deals or guides.
+    // For a true "soft delete", you'd add an `isDeleted` flag to the model.
+
+    // Example of how to handle cascading deletes if not set in schema (not recommended, better in schema)
+    // return prisma.$transaction(async (tx) => {
+    //   await tx.guide.deleteMany({ where: { userId: id } });
+    //   await tx.deal.deleteMany({ where: { userId: id } });
+    //   return tx.user.delete({ where: { id } });
+    // });
+    return prisma.user.delete({
+      where: { id },
+    });
+  },
+};


### PR DESCRIPTION
Implements the initial PostgreSQL database schema using Prisma for the WINS MVP project.

Includes:
- User, Deal, and Guide models with specified fields and relationships.
- Configuration for Prisma, including .env setup and .gitignore.
- Placeholder for initial database migration (user to run `prisma migrate dev`).
  - Instructions for subsequent migrations for indexes and soft delete fields.
- Database seed script (prisma/seed.ts) with sample data.
- Basic CRUD operations for all models in service modules (userService, dealService, guideService).
- Data validation logic within service methods (presence, format, uniqueness, existence, relational integrity).
- Indexing strategy for common queries (User.email, Deal.userId, Deal.stage, Guide.userId, Guide.dealId, Guide.meetingType).
- Soft delete implementation (deletedAt field) for Deal and Guide models, with updated service logic.
- Considerations for data privacy enforcement in the application layer.
- Outline for future data export capabilities.

This commit establishes the foundational data persistence and access layer for the application.